### PR TITLE
coverage as nose plugin (fixes #16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.pyc
 env/
+.coverage
 .vscode/
 orzeczenia/
 database.db

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
 
 test_script:
   - cmd: pycodestyle . --exclude=backend/data_xml.py
-  - cmd: nosetests tests.py
+  - cmd: nosetests --config=nose.cfg tests.py
 
 build_script:
   - cmd: python setup.py build

--- a/nose.cfg
+++ b/nose.cfg
@@ -1,0 +1,4 @@
+[nosetests]
+    verbosity=2
+    with-coverage=true
+    cover-package=/frontend/, /backend/

--- a/tests.py
+++ b/tests.py
@@ -14,8 +14,8 @@ class testTest(unittest.TestCase):
         self.assertEqual(
             self.instance.applicationframe['text'],
             "Wnioskodawcy"
-            )
+        )
         self.assertEqual(
             self.instance.staff_meeting_frame['text'],
             "Zespół orzekający"
-            )
+        )


### PR DESCRIPTION
Nosetest use plugin of coverage, so I made advantage of it. 
I'm not sure if it is a good way. The newest version of `coverage` don't fully supports `nose` and suggest other libraries (like `pytest` or `pytest-cov`).