### PR TITLE
add defined sort list

### DIFF
--- a/frontend/frames/actualdata.py
+++ b/frontend/frames/actualdata.py
@@ -3,6 +3,7 @@ from tkinter import Entry, Label, StringVar
 from tkinter.ttk import Labelframe, Combobox
 
 from backend.database import School
+from frontend.values import sorts
 
 
 class StudentData(Labelframe):
@@ -190,9 +191,7 @@ class StudentData(Labelframe):
         self.school.select_clear()
 
     def list_of_sorts(self):
-        self.sort_of_school_box['values'] = sorted(
-            i.sort for i in School.select().distinct()
-        )
+        self.sort_of_school_box['values'] = sorts
 
     def clear_all_selection(self, event):
         self.school.select_clear()

--- a/frontend/values.py
+++ b/frontend/values.py
@@ -32,6 +32,15 @@ timespan = [
     "do podjęcia nauki w szkole"
 ]
 
+sorts = [
+    "przedszkole",
+    "szkoła podstawowa",
+    "technikum",
+    "liceum ogólnokształcące",
+    "zasadnicza szkoła zawodowa",
+    "inne"
+]
+
 recommend_special_education = [
     "(należy określić zalecane warunki i formy wsparcia umożliwiające "
     "realizację indywidualnych potrzeb rozwojowych i edukacyjnych dziecka lub "

--- a/test_all.py
+++ b/test_all.py
@@ -1,13 +1,18 @@
 from tkinter import Tk
 import unittest
 from frontend.mainwindow import MainWindow
+from frontend.values import sorts
+from backend.database import School
 
 
 class testTest(unittest.TestCase):
     def setUp(self):
         self.instance = MainWindow(Tk())
 
-    def test_mainwindow_and_frames_contains_a_name(self):
+    def tearDown(self):
+        self.instance.window.destroy()
+
+    def test_Mainwindow_and_frames_contains_a_name(self):
         self.assertEqual(self.instance.notebook['text'], "Baza danych")
         self.assertEqual(self.instance.actual_student['text'], "Dane dziecka")
         self.assertEqual(
@@ -18,3 +23,9 @@ class testTest(unittest.TestCase):
             self.instance.staff_meeting_frame['text'],
             "Zespół orzekający"
         )
+
+    def test_School_class_contains_only_sort_of_sorts_list(self):
+        query = School.select()
+        list_of_sorts = [school.sort for school in query]
+        for sort in list_of_sorts:
+            self.assertIn(sort, sorts)


### PR DESCRIPTION
A new list `sorts` in `values.py` has been added. It contains every possible sort of school ie: "szkoła podstawowa", "przedszkole" etc. Earlier that list was pulled from `School` table in `DB`. It brings about some issues when new school has to be added to `DB`, eg: when `DB` is empty or doesn't contains a school of some sort.

A new test was added to `test_all.py` and `tearDown` method.